### PR TITLE
fix mp4a parsing failure

### DIFF
--- a/ISOBMFF/source/MP4A.cpp
+++ b/ISOBMFF/source/MP4A.cpp
@@ -112,8 +112,9 @@ namespace ISOBMFF
 
         // template unsigned int(32) samplerate = { default samplerate of media } << 16;
         SetSampleRateRaw( stream.ReadBigEndianUInt32() );
-
-        container.ReadData( parser, stream );
+	
+	// stoping reading here
+        // container.ReadData( parser, stream ); 
         this->impl->_boxes = container.GetBoxes();
     }
     


### PR DESCRIPTION
MP4A is a container type. In some video files, the container box lacks additional parsing data, leading to failure. This fix addresses that issue
